### PR TITLE
Use http_archive from '@bazel_tools//tools/build_defs/repo:http.bzl'

### DIFF
--- a/hugo/internal/github_hugo_theme.bzl
+++ b/hugo/internal/github_hugo_theme.bzl
@@ -1,3 +1,5 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 DEFAULT_BUILD_FILE = """
 filegroup(
     name = "files",
@@ -17,13 +19,13 @@ def github_hugo_theme(name, owner, repo, commit, **kwargs):
         commit = commit,
     )
     if "build_file" in kwargs or "build_file_content" in kwargs:
-        native.new_http_archive(name = name,
-                                url = url,
-                                strip_prefix = strip_prefix,
-                                **kwargs)
+        http_archive(name = name,
+                     url = url,
+                     strip_prefix = strip_prefix,
+                     **kwargs)
     else:
-        native.new_http_archive(name = name,
-                                url = url,
-                                strip_prefix = strip_prefix,
-                                build_file_content = DEFAULT_BUILD_FILE,
-                                **kwargs)
+        http_archive(name = name,
+                     url = url,
+                     strip_prefix = strip_prefix,
+                     build_file_content = DEFAULT_BUILD_FILE,
+                     **kwargs)

--- a/hugo/internal/hugo_repositories.bzl
+++ b/hugo/internal/hugo_repositories.bzl
@@ -1,3 +1,5 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
 HUGO_BUILD_FILE = """    
 package(default_visibility = ["//visibility:public"])
 exports_files( ["hugo"] )
@@ -12,11 +14,11 @@ def hugo_repositories(hugo_version = "0.31.1",
         os_arch = hugo_os_arch,
     )
 
-    native.new_http_archive(
+    http_archive(
         name = "hugo",
         url = hugo_url,
         build_file_content = HUGO_BUILD_FILE,
-        sha_256 = hugo_sha256,
+        sha256 = hugo_sha256,
     )
 
     


### PR DESCRIPTION
The native 'new_http_archive' is deprecated and required for newer/future Bazel versions.