### PR TITLE
hugo_site.bzl: remove use of FileType function

### DIFF
--- a/hugo/internal/hugo_site.bzl
+++ b/hugo/internal/hugo_site.bzl
@@ -85,7 +85,7 @@ hugo_site = rule(
     attrs = {
         # Hugo config file
         "config": attr.label(
-            allow_files = FileType([".toml", ".yaml", ".json"]),
+            allow_files = [".toml", ".yaml", ".json"],
             single_file = True,
             mandatory = True,
         ),


### PR DESCRIPTION
It was disabled by default as of Bazel 0.24:
https://blog.bazel.build/2019/03/26/bazel-0.24.html
https://github.com/bazelbuild/bazel/issues/5831

The resulting error message is:

    ERROR: /home/circleci/.cache/bazel/_bazel_circleci/f16e36219ef33c22efc2ad20f3e3775c/external/build_stack_rules_hugo/hugo/internal/hugo_site.bzl:88:27: Traceback (most recent call last):
	File "/home/circleci/.cache/bazel/_bazel_circleci/f16e36219ef33c22efc2ad20f3e3775c/external/build_stack_rules_hugo/hugo/internal/hugo_site.bzl", line 83
		rule(implementation = _hugo_site_impl, ...)})
	File "/home/circleci/.cache/bazel/_bazel_circleci/f16e36219ef33c22efc2ad20f3e3775c/external/build_stack_rules_hugo/hugo/internal/hugo_site.bzl", line 87, in rule
		attr.label(allow_files = FileType([".toml",..."]), <2 more arguments>)
	File "/home/circleci/.cache/bazel/_bazel_circleci/f16e36219ef33c22efc2ad20f3e3775c/external/build_stack_rules_hugo/hugo/internal/hugo_site.bzl", line 88, in attr.label
		FileType([".toml", ".yaml", ".json"])
    FileType function is not available. You may use a list of strings instead. You can temporarily reenable the function by passing the flag --incompatible_disallow_filetype=false

For this filtering to a set of extensions, a simple string list will do.