### PR TITLE
Switch to allow_single_file

### DIFF
--- a/hugo/internal/hugo_site.bzl
+++ b/hugo/internal/hugo_site.bzl
@@ -109,7 +109,7 @@ hugo_site = rule(
                 ".yml",
                 ".json",
             ],
-            single_file = True,
+            allow_single_file = True,
             mandatory = True,
         ),
         # Files to be included in the content/ subdir


### PR DESCRIPTION
```
'single_file' is no longer supported. use allow_single_file instead. You can use
--incompatible_disable_deprecated_attr_params=false to temporarily disable
this check.
```