### PR TITLE
Remove the theme path when copying it

### DIFF
--- a/hugo/internal/hugo_site.bzl
+++ b/hugo/internal/hugo_site.bzl
@@ -63,7 +63,7 @@ def _hugo_site_impl(ctx):
             if i.short_path.startswith("../"):
                 o_filename = "/".join(["themes", theme.name] + i.short_path.split("/")[2:])
             else:
-                o_filename = "/".join(["themes", theme.name, i.short_path])
+                o_filename = "/".join(["themes", theme.name, i.short_path[len(theme.path):]])
             o = ctx.actions.declare_file(o_filename)
             ctx.action(
                 inputs = [i],

--- a/hugo/internal/hugo_theme.bzl
+++ b/hugo/internal/hugo_theme.bzl
@@ -2,6 +2,7 @@ def _hugo_theme_impl(ctx):
     return struct(
         hugo_theme = struct(
             name = ctx.attr.theme_name or ctx.label.name,
+            path = ctx.label.package,
             files = depset(ctx.files.srcs),
         ),
     )


### PR DESCRIPTION
This fixes #18.

I tested it with two different scenarios: a theme defined "deep" in the repo tree (situation presented in #18), and with a theme defined from a GitHub repo and in the root `BUILD` file (copy-pasted from the sample in `test/basic`, which I sadly can't run (I'm not exactly sure why, `_content.md` is not found despite being in the folder - it also fails on `master` for me, it's unrelated.)