### PR TITLE
Add support for generated files

### DIFF
--- a/hugo/internal/hugo_site.bzl
+++ b/hugo/internal/hugo_site.bzl
@@ -19,14 +19,17 @@ def relative_path(src, dirname):
 def copy_to_dir(ctx, srcs, dirname):
     outs = []
     for i in srcs:
-        o = ctx.actions.declare_file(relative_path(i, dirname))
-        ctx.actions.run_shell(
-            inputs = [i],
-            outputs = [o],
-            command = 'cp "$1" "$2"',
-            arguments = [i.path, o.path],
-        )
-        outs.append(o)
+        if i.is_source:
+            o = ctx.actions.declare_file(relative_path(i, dirname))
+            ctx.actions.run(
+                inputs = [i],
+                executable = "cp",
+                arguments = [i.path, o.path],
+                outputs = [o],
+            )
+            outs.append(o)
+        else:
+            outs.append(i)
     return outs
 
 def _hugo_site_impl(ctx):
@@ -47,14 +50,16 @@ def _hugo_site_impl(ctx):
     hugo_inputs.append(config_file)
 
     # Copy all the files over
-    content_files = copy_to_dir(ctx, ctx.files.content, "content")
-    static_files = copy_to_dir(ctx, ctx.files.static, "static")
-    image_files = copy_to_dir(ctx, ctx.files.images, "images")
-    layout_files = copy_to_dir(ctx, ctx.files.layouts, "layouts")
-    data_files = copy_to_dir(ctx, ctx.files.data, "data")
-    asset_files = copy_to_dir(ctx, ctx.files.assets, "assets")
-    i18n_files = copy_to_dir(ctx, ctx.files.assets, "i18n")
-    hugo_inputs += content_files + static_files + image_files + layout_files + asset_files + data_files + i18n_files
+    for name, srcs in {
+        "assets": ctx.files.assets,
+        "content": ctx.files.content,
+        "data": ctx.files.data,
+        "i18n": ctx.files.i18n,
+        "images": ctx.files.images,
+        "layouts": ctx.files.layouts,
+        "static": ctx.files.static,
+    }.items():
+        hugo_inputs += copy_to_dir(ctx, srcs, name)
 
     # Copy the theme
     if ctx.attr.theme:


### PR DESCRIPTION
Fixes #21

With that patch, we can add rules that generate files in the `content` attribute of the `hugo_site` rule.

For instance, we can have a rule like: 
```
genrule(
    name = "api",
    outs = ["api.md"],
    cmd = """echo "Some generated content" > $@""",
    visibility = ["//visibility:public"],
)
```

And depend on it like:
```
hugo_site(
   content = ... + ["//site/content/subsection:api"],
   ...
)
```