### PR TITLE
resolve hugo errors related to symlinks

### DIFF
--- a/hugo/internal/hugo_site.bzl
+++ b/hugo/internal/hugo_site.bzl
@@ -85,7 +85,7 @@ def _hugo_site_impl(ctx):
             ctx.actions.run_shell(
                 inputs = [i],
                 outputs = [o],
-                command = 'cp -r "$1" "$2"',
+                command = 'cp -r -L "$1" "$2"',
                 arguments = [i.path, o.path],
             )
             hugo_inputs.append(o)


### PR DESCRIPTION
Depending on the OS distribution cp might not follow the symlinks when the -r parameter is provided, 
but just copy them. The result is that hugo doesn't like the symlinks in the themes and it aborts. 

This is a simple PR that adds a -L parameter in the copy to force symlinks to be resolved avoids the crash. 

This will also resolve #27 that has been open for a while.