### PR TITLE
Fix link to bazel icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 
 <table><tr>
-<td><img src="https://bazel.build/images/bazel-icon.svg" height="120"/></td>
+<td><img src="https://raw.githubusercontent.com/bazelbuild/bazel-blog/master/images/bazel-icon.svg" height="120"/></td>
 <td><img src="https://raw.githubusercontent.com/gohugoio/hugoDocs/master/static/img/hugo-logo.png" height="120"/></td>
 </tr><tr>
 <td>Rules</td>


### PR DESCRIPTION
Fix link to Bazel icon

Currently it looks like this:

![image](https://user-images.githubusercontent.com/3775001/201466819-099a453d-aa8b-4460-add3-734a59ce88c2.png)

Afterwards it looks like this:

![image](https://user-images.githubusercontent.com/3775001/201466836-47c4f87a-d9d8-4d26-b241-a139c407e2ac.png)

