### PR TITLE
use os_arch if specified

### DIFF
--- a/hugo/internal/hugo_repository.bzl
+++ b/hugo/internal/hugo_repository.bzl
@@ -1,6 +1,6 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-HUGO_BUILD_FILE = """    
+HUGO_BUILD_FILE = """
 package(default_visibility = ["//visibility:public"])
 exports_files( ["hugo"] )
 """
@@ -13,7 +13,9 @@ def _hugo_repository_impl(repository_ctx):
     os_arch = repository_ctx.attr.os_arch
 
     os_name = repository_ctx.os.name.lower()
-    if os_name.startswith("mac os"):
+    if os_arch != "":
+        os_arch = os_arch
+    elif os_name.startswith("mac os"):
         os_arch = "macOS-64bit"
     elif os_name.find("windows") != -1:
         os_arch = "Windows-64bit"


### PR DESCRIPTION
Hey! 

The Hugo releases (as of v0.103.0) use `darwin-universal` in their name for macOS releases. Since this is still a fairly recent change, this commit just lets the configured `os_arch` override everything.