### PR TITLE
Fix verbose for Hugo ≥0.114.0

### DIFF
--- a/hugo/internal/hugo_site.bzl
+++ b/hugo/internal/hugo_site.bzl
@@ -244,8 +244,9 @@ def _hugo_serve_impl(ctx):
 
     if ctx.attr.quiet:
         hugo_args.append("--quiet")
-    if ctx.attr.quiet:
-        hugo_args.append("--verbose")
+    if ctx.attr.verbose:
+        hugo_args.append("--logLevel")
+        hugo_args.append("info")
     if ctx.attr.disable_fast_render:
         hugo_args.append("--disableFastRender")
 


### PR DESCRIPTION
Fixes two issues:

- Verbose was being applied when quiet=True
- Verbose was being applied using the deprecated `--verbose` flag, which has been changed to `--logLevel info` from Hugo 0.114.0
  - See https://github.com/gohugoio/hugo/pull/11088